### PR TITLE
Add simple node server with sqlite

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "chat",
+  "version": "1.0.0",
+  "description": "",
+  "main": "pdf-export.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "dependencies": {
+    "express": "^4.18.0",
+    "sqlite3": "^5.1.0"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,33 @@
+const express = require('express');
+const sqlite3 = require('sqlite3').verbose();
+const app = express();
+const port = 3000;
+
+app.use(express.json());
+
+const db = new sqlite3.Database('./texte.db');
+
+db.serialize(() => {
+  db.run('CREATE TABLE IF NOT EXISTS beitraege (id INTEGER PRIMARY KEY AUTOINCREMENT, inhalt TEXT)');
+});
+
+app.post('/eintrag', (req, res) => {
+  const text = req.body.text;
+  db.run('INSERT INTO beitraege (inhalt) VALUES (?)', [text], function (err) {
+    if (err) {
+      return res.status(500).send('Fehler beim Speichern');
+    }
+    res.json({ id: this.lastID });
+  });
+});
+
+app.get('/beitraege', (req, res) => {
+  db.all('SELECT * FROM beitraege', (err, rows) => {
+    if (err) {
+      return res.status(500).send('Fehler beim Abrufen');
+    }
+    res.json(rows);
+  });
+});
+
+app.listen(port, () => console.log(`Server läuft auf http://localhost:${port}`));


### PR DESCRIPTION
## Summary
- set up package.json with express and sqlite3 dependencies
- add `server.js` implementing an Express server that writes/reads text entries from a SQLite DB

## Testing
- `npm install express sqlite3` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68460acf9ac083238b204fbd1f3b1ed2