### PR TITLE
Add editor page and routes

### DIFF
--- a/EditorInhalte.html
+++ b/EditorInhalte.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Editor Inhalte</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+<a href="index.html">Zurück zum Index</a>
+<h1>Editor Inhalte</h1>
+<form id="editor-form">
+    <textarea name="text1" placeholder="Text 1" rows="6" cols="60"></textarea>
+    <textarea name="text2" placeholder="Text 2" rows="6" cols="60"></textarea>
+    <textarea name="text3" placeholder="Text 3" rows="6" cols="60"></textarea>
+    <button type="submit">Speichern</button>
+</form>
+<script src="editor.js"></script>
+</body>
+</html>

--- a/editor.js
+++ b/editor.js
@@ -1,0 +1,19 @@
+document.getElementById('editor-form').addEventListener('submit', function (e) {
+  e.preventDefault();
+  const data = {
+    text1: this.text1.value,
+    text2: this.text2.value,
+    text3: this.text3.value,
+  };
+
+  fetch('http://localhost:3000/editorinhalte', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data),
+  })
+    .then((r) => r.json())
+    .then((d) => {
+      alert('Gespeichert mit ID: ' + d.id);
+    })
+    .catch(() => alert('Fehler beim Speichern'));
+});

--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@
 
 </head>
 <body>
+<a href="EditorInhalte.html">EditorInhalte</a>
 
 <div class="section left">
     <div class="top">

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "chat",
+  "version": "1.0.0",
+  "description": "",
+  "main": "pdf-export.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "dependencies": {
+    "express": "^4.18.0",
+    "sqlite3": "^5.1.0"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,62 @@
+const express = require('express');
+const sqlite3 = require('sqlite3').verbose();
+const app = express();
+const port = 3000;
+
+app.use(express.json());
+
+const db = new sqlite3.Database('./texte.db');
+
+db.serialize(() => {
+  db.run('CREATE TABLE IF NOT EXISTS beitraege (id INTEGER PRIMARY KEY AUTOINCREMENT, inhalt TEXT)');
+  db.run(`CREATE TABLE IF NOT EXISTS editorinhalte (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    text1 TEXT,
+    text2 TEXT,
+    text3 TEXT
+  )`);
+});
+
+app.post('/eintrag', (req, res) => {
+  const text = req.body.text;
+  db.run('INSERT INTO beitraege (inhalt) VALUES (?)', [text], function (err) {
+    if (err) {
+      return res.status(500).send('Fehler beim Speichern');
+    }
+    res.json({ id: this.lastID });
+  });
+});
+
+app.get('/beitraege', (req, res) => {
+  db.all('SELECT * FROM beitraege', (err, rows) => {
+    if (err) {
+      return res.status(500).send('Fehler beim Abrufen');
+    }
+    res.json(rows);
+  });
+});
+
+app.post('/editorinhalte', (req, res) => {
+  const { text1, text2, text3 } = req.body;
+  db.run(
+    'INSERT INTO editorinhalte (text1, text2, text3) VALUES (?, ?, ?)',
+    [text1, text2, text3],
+    function (err) {
+      if (err) {
+        return res.status(500).send('Fehler beim Speichern');
+      }
+      res.json({ id: this.lastID });
+    }
+  );
+});
+
+app.get('/editorinhalte', (req, res) => {
+  db.all('SELECT * FROM editorinhalte', (err, rows) => {
+    if (err) {
+      return res.status(500).send('Fehler beim Abrufen');
+    }
+    res.json(rows);
+  });
+});
+
+app.listen(port, () => console.log(`Server läuft auf http://localhost:${port}`));


### PR DESCRIPTION
## Summary
- create `EditorInhalte.html` with three textareas and save button
- add `editor.js` to POST form data to the server
- expand `server.js` with new table and routes for editor content
- link new page from `index.html`

## Testing
- No tests included


------
https://chatgpt.com/codex/tasks/task_e_68460acf9ac083238b204fbd1f3b1ed2